### PR TITLE
feat: replace per-operation limits with 5MB aggregate data cap for storeFileWrite

### DIFF
--- a/src/api/TypesValidator.ts
+++ b/src/api/TypesValidator.ts
@@ -64,6 +64,7 @@ export class TypesValidator {
     storeData: Validator;
     storeFileId: Validator;
     storeFileMeta: Validator;
+    storeFileOperations: Validator;
     listModel: ObjectValidator;
     inboxId: Validator;
     inboxData: Validator;
@@ -236,6 +237,20 @@ export class TypesValidator {
         this.storeData = this.unknown4Kb;
         this.storeFileId = id;
         this.storeFileMeta = this.unknown4Kb;
+        this.storeFileOperations = this.builder.createCustom((value, _validator, checker) => {
+            const storeFileOperation = this.builder.createObject({
+                type: this.builder.createEnum(["file", "checksum"]),
+                pos: this.builder.min(this.builder.int, -1),
+                data: this.byteBuffer,
+                truncate: this.builder.bool,
+            });
+            const maxSize = 5242880;
+            checker.validateValue(value, this.builder.createList(storeFileOperation));
+            const totalDataSize = (value as {data: Buffer}[]).reduce((sum, op) => sum + op.data.length, 0);
+            if (totalDataSize > maxSize) {
+                throw new Error(`Total operations data size ${totalDataSize} exceeds limit of ${maxSize} bytes`);
+            }
+        });
         this.queryValue = this.builder.createOneOf([this.builder.int, this.builder.string, this.builder.bool, this.builder.nullValue]);
         this.queryProperty = this.builder.createOneOf([this.queryValue, this.builder.createObject({
             $gt: this.builder.optional(this.builder.int),

--- a/src/api/main/store/StoreApiValidator.ts
+++ b/src/api/main/store/StoreApiValidator.ts
@@ -108,12 +108,7 @@ export class StoreApiValidator extends BaseValidator {
             this.builder.createObject({
                 fileId: this.tv.storeFileId,
                 meta: this.tv.storeFileMeta,
-                operations: this.builder.createListWithRangeLength(this.builder.createObject({
-                    type: this.builder.createEnum(["file", "checksum"]),
-                    pos: this.builder.min(this.builder.int, -1),
-                    data: this.builder.maxLength(this.tv.byteBuffer, 524288),
-                    truncate: this.builder.bool,
-                }), 1, 4),
+                operations: this.tv.storeFileOperations,
                 keyId: this.tv.keyId,
                 version: this.tv.intNonNegative,
                 force: this.builder.bool,


### PR DESCRIPTION
# Summary

- Adds `storeFileOperations` validator to `TypesValidator` that enforces
  a 5MB cap on the total combined size of `data` across all operations
- Replaces the previous inline validator in `storeFileWrite` which limited
  operations to 1–4 items with a max 512KB per `data` field
- The new validator imposes no count limit on operations, only the aggregate
  5MB total, giving clients more flexibility in how they split writes