### PR TITLE
feat: add distributed resource lock API with hierarchical lock levels

### DIFF
--- a/src/api/main/lock/LockApi.ts
+++ b/src/api/main/lock/LockApi.ts
@@ -1,0 +1,46 @@
+/*!
+PrivMX Bridge.
+Copyright © 2026 Simplito sp. z o.o.
+
+This file is part of the PrivMX Platform (https://privmx.dev).
+This software is Licensed under the PrivMX Free License.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as lockApi from "./LockApiTypes";
+import { LockService } from "../../../service/cloud/LockService";
+import { ApiMethod } from "../../Decorators";
+import { SessionService } from "../../session/SessionService";
+import { LockApiValidator } from "./LockApiValidator";
+import { BaseApi } from "../../BaseApi";
+
+export class LockApi extends BaseApi implements lockApi.ILockApi {
+    
+    constructor(
+        lockApiValidator: LockApiValidator,
+        private lockService: LockService,
+        private sessionService: SessionService,
+    ) {
+        super(lockApiValidator);
+    }
+    
+    @ApiMethod({})
+    async lockLock(model: lockApi.LockLockModel): Promise<lockApi.LockOperationResult> {
+        this.sessionService.validateContextSessionAndGetCloudUser();
+        return this.lockService.lock(model.resourceId, model.uuid, model.lockLevel);
+    }
+    
+    @ApiMethod({})
+    async lockUnlock(model: lockApi.LockUnlockModel): Promise<lockApi.LockOperationResult> {
+        this.sessionService.validateContextSessionAndGetCloudUser();
+        return this.lockService.unlock(model.resourceId, model.uuid, model.lockLevel);
+    }
+    
+    @ApiMethod({})
+    async lockCheckReservedLock(model: lockApi.LockCheckReservedLockModel): Promise<lockApi.LockCheckReservedLockResult> {
+        this.sessionService.validateContextSessionAndGetCloudUser();
+        return this.lockService.checkReservedLock(model.resourceId, model.uuid);
+    }
+}

--- a/src/api/main/lock/LockApiTypes.ts
+++ b/src/api/main/lock/LockApiTypes.ts
@@ -1,0 +1,44 @@
+/*!
+PrivMX Bridge.
+Copyright © 2026 Simplito sp. z o.o.
+
+This file is part of the PrivMX Platform (https://privmx.dev).
+This software is Licensed under the PrivMX Free License.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type LockLevel = "none" | "shared" | "reserved" | "pending" | "exclusive";
+
+export interface LockLockModel {
+    resourceId: string;
+    uuid: string;
+    lockLevel: Exclude<LockLevel, "none">;
+}
+
+export interface LockUnlockModel {
+    resourceId: string;
+    uuid: string;
+    lockLevel: "none" | "shared";
+}
+
+export interface LockOperationResult {
+    success: boolean;
+    currentLevel: LockLevel;
+}
+
+export interface LockCheckReservedLockModel {
+    resourceId: string;
+    uuid: string;
+}
+
+export interface LockCheckReservedLockResult {
+    reserved: boolean;
+}
+
+export interface ILockApi {
+    lockLock(model: LockLockModel): Promise<LockOperationResult>;
+    lockUnlock(model: LockUnlockModel): Promise<LockOperationResult>;
+    lockCheckReservedLock(model: LockCheckReservedLockModel): Promise<LockCheckReservedLockResult>;
+}

--- a/src/api/main/lock/LockApiValidator.ts
+++ b/src/api/main/lock/LockApiValidator.ts
@@ -1,0 +1,37 @@
+/*!
+PrivMX Bridge.
+Copyright © 2026 Simplito sp. z o.o.
+
+This file is part of the PrivMX Platform (https://privmx.dev).
+This software is Licensed under the PrivMX Free License.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { BaseValidator } from "../../BaseValidator";
+import { TypesValidator } from "../../TypesValidator";
+
+export class LockApiValidator extends BaseValidator {
+    
+    constructor(
+        private tv: TypesValidator,
+    ) {
+        super();
+        
+        this.registerMethod("lockLock", this.builder.createObject({
+            resourceId: this.tv.id,
+            uuid: this.tv.id,
+            lockLevel: this.builder.createEnum(["shared", "reserved", "pending", "exclusive"]),
+        }));
+        this.registerMethod("lockUnlock", this.builder.createObject({
+            resourceId: this.tv.id,
+            uuid: this.tv.id,
+            lockLevel: this.builder.createEnum(["none", "shared"]),
+        }));
+        this.registerMethod("lockCheckReservedLock", this.builder.createObject({
+            resourceId: this.tv.id,
+            uuid: this.tv.id,
+        }));
+    }
+}

--- a/src/cluster/master/MasterRegistry.ts
+++ b/src/cluster/master/MasterRegistry.ts
@@ -29,6 +29,7 @@ import { Callbacks } from "../../service/event/Callbacks";
 import { MetricsContainer } from "./ipcServices/MetricsContainer";
 import { ActiveUsersMap } from "./ipcServices/ActiveUsers";
 import { LockService } from "./ipcServices/LockService";
+import { CloudLockService } from "./ipcServices/CloudLockService";
 import { WebsocketCommunicationManger } from "./ipcServices/WebsocketCommunicationManager";
 import { IBrokerClient } from "../common/BrokerClient";
 import { MetricsCollector } from "../../service/misc/MetricsCollector";
@@ -56,6 +57,7 @@ export class MasterRegistry {
     private callbacks?: Callbacks;
     private plugins: MasterPlugin[] = [];
     private lockService?: LockService;
+    private cloudLockService?: CloudLockService;
     private websocketCommunicationManager?: WebsocketCommunicationManger;
     private aggregatedNotificationsService?: AggregatedNotificationsService;
     private metricsCollector?: MetricsCollector;
@@ -146,6 +148,7 @@ export class MasterRegistry {
         methodExecutor.register(this.getActiveUsersMap());
         methodExecutor.register(this.getJanusRoomsWatcherCache());
         methodExecutor.register(this.getLockService());
+        methodExecutor.register(this.getCloudLockService());
         methodExecutor.register(this.getWebsocketCommunicationManager());
         methodExecutor.register(this.getAggregatedNotificationsService());
         this.getCallbacks().triggerSync("registerIpcServices", []);
@@ -242,6 +245,13 @@ export class MasterRegistry {
             this.lockService = new LockService();
         }
         return this.lockService;
+    }
+    
+    getCloudLockService() {
+        if (this.cloudLockService == null) {
+            this.cloudLockService = new CloudLockService();
+        }
+        return this.cloudLockService;
     }
     
     getActiveUsersMap() {

--- a/src/cluster/master/ipcServices/CloudLockService.ts
+++ b/src/cluster/master/ipcServices/CloudLockService.ts
@@ -1,0 +1,176 @@
+/*!
+PrivMX Bridge.
+Copyright © 2026 Simplito sp. z o.o.
+
+This file is part of the PrivMX Platform (https://privmx.dev).
+This software is Licensed under the PrivMX Free License.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { ApiMethod } from "../../../api/Decorators";
+import { IpcService } from "../Decorators";
+
+export type LockLevel = "none" | "shared" | "reserved" | "pending" | "exclusive";
+type LockLevelNumeric = 0 | 1 | 2 | 3 | 4;
+
+export interface LockResult {
+    success: boolean;
+    currentLevel: LockLevel;
+}
+
+interface Lock {
+    lockId: string;
+    timestamp: number;
+    level: LockLevelNumeric;
+}
+
+interface LockSet {
+    writerLock: Lock | null;
+    readerLocks: Map<string, Lock>;
+}
+
+const LOCK_LEVEL_ORDER: Record<LockLevel, LockLevelNumeric> = {
+    none: 0,
+    shared: 1,
+    reserved: 2,
+    pending: 3,
+    exclusive: 4,
+};
+
+const LOCK_LEVEL_NAME: LockLevel[] = ["none", "shared", "reserved", "pending", "exclusive"];
+
+const TIMEOUT_DELTA = 30_000;
+
+@IpcService
+export class CloudLockService {
+    
+    private locks = new Map<string, LockSet>();
+    
+    @ApiMethod({})
+    async resourceLock(model: {resourceId: string, uuid: string, lockLevel: Exclude<LockLevel, "none">}): Promise<LockResult> {
+        const lockSet = this.getOrCreateLockSet(model.resourceId);
+        const level = LOCK_LEVEL_ORDER[model.lockLevel];
+        const myLock = this.getMyLock(lockSet, model.uuid);
+        
+        if (myLock.level >= level) {
+            return { success: true, currentLevel: LOCK_LEVEL_NAME[myLock.level] };
+        }
+        
+        this.deleteTimeoutedLocks(lockSet);
+        
+        if (level === LOCK_LEVEL_ORDER.shared) {
+            if (lockSet.writerLock !== null && lockSet.writerLock.level !== LOCK_LEVEL_ORDER.reserved) {
+                return { success: false, currentLevel: LOCK_LEVEL_NAME[this.getMyLock(lockSet, model.uuid).level] };
+            }
+            lockSet.readerLocks.set(model.uuid, this.createLock(model.uuid, level));
+            return { success: true, currentLevel: "shared" };
+        }
+        
+        if (level === LOCK_LEVEL_ORDER.reserved || level === LOCK_LEVEL_ORDER.pending) {
+            if (lockSet.writerLock !== null && lockSet.writerLock.lockId !== model.uuid) {
+                return { success: false, currentLevel: LOCK_LEVEL_NAME[this.getMyLock(lockSet, model.uuid).level] };
+            }
+            this.deleteMyLocks(lockSet, model.uuid);
+            lockSet.writerLock = this.createLock(model.uuid, level);
+            return { success: true, currentLevel: LOCK_LEVEL_NAME[level] };
+        }
+        
+        if (level === LOCK_LEVEL_ORDER.exclusive) {
+            if (lockSet.writerLock !== null && lockSet.writerLock.lockId !== model.uuid) {
+                return { success: false, currentLevel: LOCK_LEVEL_NAME[this.getMyLock(lockSet, model.uuid).level] };
+            }
+            this.deleteMyLocks(lockSet, model.uuid);
+            if (lockSet.readerLocks.size > 0) {
+                if (myLock.level === LOCK_LEVEL_ORDER.pending) {
+                    return { success: false, currentLevel: "pending" };
+                }
+                lockSet.writerLock = this.createLock(model.uuid, LOCK_LEVEL_ORDER.pending);
+                return { success: false, currentLevel: "pending" };
+            }
+            lockSet.writerLock = this.createLock(model.uuid, level);
+            return { success: true, currentLevel: "exclusive" };
+        }
+        
+        return { success: false, currentLevel: "none" };
+    }
+    
+    @ApiMethod({})
+    async resourceCheckReservedLock(model: {resourceId: string, uuid: string}): Promise<{reserved: boolean}> {
+        const lockSet = this.getOrCreateLockSet(model.resourceId);
+        this.deleteTimeoutedLocks(lockSet);
+        const reserved = lockSet.writerLock !== null &&
+            lockSet.writerLock.lockId !== model.uuid &&
+            lockSet.writerLock.level >= LOCK_LEVEL_ORDER.reserved;
+        return { reserved };
+    }
+    
+    @ApiMethod({})
+    async resourceUnlock(model: {resourceId: string, uuid: string, lockLevel: "none" | "shared"}): Promise<LockResult> {
+        const lockSet = this.getOrCreateLockSet(model.resourceId);
+        const level = LOCK_LEVEL_ORDER[model.lockLevel];
+        const myLock = this.getMyLock(lockSet, model.uuid);
+        
+        if (myLock.level <= level) {
+            return { success: true, currentLevel: LOCK_LEVEL_NAME[myLock.level] };
+        }
+        
+        this.deleteTimeoutedLocks(lockSet);
+        
+        if (level === LOCK_LEVEL_ORDER.none) {
+            this.deleteMyLocks(lockSet, model.uuid);
+            return { success: true, currentLevel: "none" };
+        }
+        
+        if (level === LOCK_LEVEL_ORDER.shared) {
+            this.deleteMyLocks(lockSet, model.uuid);
+            if (lockSet.writerLock !== null) {
+                return { success: false, currentLevel: LOCK_LEVEL_NAME[this.getMyLock(lockSet, model.uuid).level] };
+            }
+            lockSet.readerLocks.set(model.uuid, this.createLock(model.uuid, level));
+            return { success: true, currentLevel: "shared" };
+        }
+        
+        return { success: false, currentLevel: LOCK_LEVEL_NAME[this.getMyLock(lockSet, model.uuid).level] };
+    }
+    
+    private getOrCreateLockSet(resourceId: string): LockSet {
+        let lockSet = this.locks.get(resourceId);
+        if (!lockSet) {
+            lockSet = { writerLock: null, readerLocks: new Map() };
+            this.locks.set(resourceId, lockSet);
+        }
+        return lockSet;
+    }
+    
+    private getMyLock(lockSet: LockSet, uuid: string): Lock {
+        if (lockSet.writerLock !== null && lockSet.writerLock.lockId === uuid) {
+            return lockSet.writerLock;
+        }
+        return lockSet.readerLocks.get(uuid) ?? { lockId: uuid, timestamp: 0, level: 0 };
+    }
+    
+    private createLock(uuid: string, level: LockLevelNumeric): Lock {
+        return { lockId: uuid, timestamp: Date.now(), level };
+    }
+    
+    private deleteMyLocks(lockSet: LockSet, uuid: string): void {
+        if (lockSet.writerLock !== null && lockSet.writerLock.lockId === uuid) {
+            lockSet.writerLock = null;
+        }
+        lockSet.readerLocks.delete(uuid);
+    }
+    
+    private deleteTimeoutedLocks(lockSet: LockSet): void {
+        const timeoutTimestamp = Date.now() - TIMEOUT_DELTA;
+        if (lockSet.writerLock !== null && lockSet.writerLock.timestamp <= timeoutTimestamp) {
+            lockSet.writerLock = null;
+        }
+        for (const [id, lock] of lockSet.readerLocks) {
+            if (lock.timestamp <= timeoutTimestamp) {
+                lockSet.readerLocks.delete(id);
+            }
+        }
+    }
+}

--- a/src/cluster/worker/WorkerRegistry.ts
+++ b/src/cluster/worker/WorkerRegistry.ts
@@ -43,6 +43,7 @@ import { SignatureVerificationService } from "../../service/auth/SignatureVerifi
 import { ActiveUsersMap } from "../master/ipcServices/ActiveUsers";
 import { HostList } from "./HostList";
 import { LockService } from "../master/ipcServices/LockService";
+import { CloudLockService } from "../master/ipcServices/CloudLockService";
 import { WebsocketCommunicationManger } from "../master/ipcServices/WebsocketCommunicationManager";
 import { SubscriberMessageProcessor } from "../common/SubscriberMesageProcessor";
 import { IBrokerClient } from "../common/BrokerClient";
@@ -417,6 +418,10 @@ export class WorkerRegistry {
     
     getLockService() {
         return this.getIpcService<LockService>("lockService");
+    }
+    
+    getCloudLockService() {
+        return this.getIpcService<CloudLockService>("cloudLockService");
     }
     
     getIpcService<T>(serviceName: string) {

--- a/src/service/cloud/LockService.ts
+++ b/src/service/cloud/LockService.ts
@@ -1,0 +1,33 @@
+/*!
+PrivMX Bridge.
+Copyright © 2026 Simplito sp. z o.o.
+
+This file is part of the PrivMX Platform (https://privmx.dev).
+This software is Licensed under the PrivMX Free License.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { CloudLockService, LockLevel, LockResult } from "../../cluster/master/ipcServices/CloudLockService";
+
+export { LockLevel, LockResult };
+
+export class LockService {
+    
+    constructor(
+        private ipcService: CloudLockService,
+    ) {}
+    
+    lock(resourceId: string, uuid: string, lockLevel: Exclude<LockLevel, "none">): Promise<LockResult> {
+        return this.ipcService.resourceLock({resourceId, uuid, lockLevel});
+    }
+    
+    unlock(resourceId: string, uuid: string, lockLevel: "none" | "shared"): Promise<LockResult> {
+        return this.ipcService.resourceUnlock({resourceId, uuid, lockLevel});
+    }
+    
+    checkReservedLock(resourceId: string, uuid: string): Promise<{reserved: boolean}> {
+        return this.ipcService.resourceCheckReservedLock({resourceId, uuid});
+    }
+}

--- a/src/service/ioc/IOC.ts
+++ b/src/service/ioc/IOC.ts
@@ -124,6 +124,9 @@ import { LockHelper } from "../misc/LockHelper";
 import { UserStatusManager } from "../cloud/UserStatusManager";
 import { JanusContextFactory } from "../cloud/JanusContextFactory";
 import { JanusRoomsWatcher } from "../cloud/JanusRoomsWatcher";
+import { LockApi } from "../../api/main/lock/LockApi";
+import { LockApiValidator } from "../../api/main/lock/LockApiValidator";
+import { LockService } from "../cloud/LockService";
 export class IOC {
     
     takeMongoClientFromWorker = true;
@@ -229,6 +232,8 @@ export class IOC {
     protected userStatusManager?: UserStatusManager;
     protected janusContextFactory?: JanusContextFactory;
     protected janusRoomsWatcher?: JanusRoomsWatcher;
+    protected lockApiValidator?: LockApiValidator;
+    protected cloudLockService?: LockService;
     
     constructor(instanceHost: types.core.Host, workerRegistry: WorkerRegistry) {
         this.instanceHost = instanceHost;
@@ -595,6 +600,8 @@ export class IOC {
             if (!!this.workerRegistry.getConfig().streams.enabled) {
                 this.mainApiRsolver.registerApiWithPrefix("stream.", StreamApi, ({ioc: e, sessionService: s}) => new StreamApi(e.ioc.getStreamApiValidator(), s, e.ioc.getStreamService(), e.ioc.getStreamConverter(), e.getRequestLogger(), e.webSocket, e.ioc.getTurnCredentialsService()));
             }
+            this.mainApiRsolver.registerApiWithPrefix("lock.", LockApi, ({ioc: e, sessionService: s}) => new LockApi(e.ioc.getLockApiValidator(), e.ioc.getCloudLockService(), s));
+            
             this.getPluginsManager().registerEndpoint(this.mainApiRsolver);
         }
         return this.mainApiRsolver;
@@ -1094,6 +1101,22 @@ export class IOC {
             );
         }
         return this.storeApiValidator;
+    }
+    
+    getLockApiValidator() {
+        if (this.lockApiValidator == null) {
+            this.lockApiValidator = new LockApiValidator(
+                this.getTypesValidator(),
+            );
+        }
+        return this.lockApiValidator;
+    }
+    
+    getCloudLockService() {
+        if (this.cloudLockService == null) {
+            this.cloudLockService = new LockService(this.workerRegistry.getCloudLockService());
+        }
+        return this.cloudLockService;
     }
     
     getLockHelper() {


### PR DESCRIPTION
## Summary

Adds a dedicated Lock API for resource synchronization, replacing the previous KVDB-based approach with a purpose-built distributed locking mechanism.

### What's new

- `CloudLockService` — IPC master service managing locks across all worker processes
- Four hierarchical lock levels: `shared` → `reserved` → `pending` → `exclusive`
- 30s auto-expiry for stale locks (crash-safe)
- Three new API endpoints:
  - `lock.lockLock` — acquire a lock at the requested level
  - `lock.lockUnlock` — release or downgrade a lock
  - `lock.lockCheckReservedLock` — check if any other owner holds a `reserved`-or-higher lock on a resource

### Why

- **Fewer requests to Bridge** — a single `lockLock` call replaces the previous read + conditional write pattern against KVDB
- **Eliminates race conditions** — the lock is acquired atomically in a single step; there is no window between reading and writing
