### PR TITLE
feat: add kvdb.kvdbEntryFind endpoint returning null on missing entry

### DIFF
--- a/src/api/main/kvdb/KvdbApi.ts
+++ b/src/api/main/kvdb/KvdbApi.ts
@@ -106,6 +106,17 @@ export class KvdbApi extends BaseApi implements kvdbApi.IKvdbApi {
     }
     
     @ApiMethod({})
+    async kvdbEntryFind(model: kvdbApi.KvdbEntryGetModel): Promise<kvdbApi.KvdbEntryFindResult> {
+        const cloudUser = this.sessionService.validateContextSessionAndGetCloudUser();
+        const result = await this.kvdbService.findKvdbEntry(cloudUser, model.kvdbId, model.kvdbEntryKey);
+        if (result === null) {
+            return {kvdbEntry: null};
+        }
+        this.requestLogger.setContextId(result.kvdb.contextId);
+        return {kvdbEntry: this.kvdbConverter.convertKvdbEntry(result.kvdb, result.item)};
+    }
+    
+    @ApiMethod({})
     async kvdbEntryDelete(model: kvdbApi.KvdbEntryDeleteModel): Promise<types.core.OK> {
         const cloudUser = this.sessionService.validateContextSessionAndGetCloudUser();
         const {kvdb} = await this.kvdbService.deleteItem(cloudUser, model.kvdbId, model.kvdbEntryKey);

--- a/src/api/main/kvdb/KvdbApiClient.ts
+++ b/src/api/main/kvdb/KvdbApiClient.ts
@@ -47,6 +47,10 @@ export class KvdbApiClient extends BaseApiClient implements kvdbApi.IKvdbApi {
         return this.request("kvdb.kvdbEntryGet", model);
     }
     
+    kvdbEntryFind(model: kvdbApi.KvdbEntryGetModel): Promise<kvdbApi.KvdbEntryFindResult> {
+        return this.request("kvdb.kvdbEntryFind", model);
+    }
+    
     kvdbEntrySet(model: kvdbApi.KvdbEntrySetModel): Promise<types.core.OK> {
         return this.request("kvdb.kvdbEntrySet", model);
     }

--- a/src/api/main/kvdb/KvdbApiTypes.ts
+++ b/src/api/main/kvdb/KvdbApiTypes.ts
@@ -198,6 +198,10 @@ export interface KvdbEntryGetResult {
     kvdbEntry: KvdbEntryInfo;
 }
 
+export interface KvdbEntryFindResult {
+    kvdbEntry: KvdbEntryInfo | null;
+}
+
 export type KvdbListAllResult = KvdbListResult;
 
 export interface KvdbListKeysModel extends types.core.ListModel {
@@ -240,6 +244,7 @@ export interface IKvdbApi {
     kvdbList(model: KvdbListModel): Promise<KvdbListResult>;
     kvdbListAll(model: KvdbListAllModel): Promise<KvdbListAllResult>;
     kvdbEntryGet(model: KvdbEntryGetModel): Promise<KvdbEntryGetResult>;
+    kvdbEntryFind(model: KvdbEntryGetModel): Promise<KvdbEntryFindResult>;
     kvdbEntrySet(model: KvdbEntrySetModel): Promise<types.core.OK>;
     kvdbEntryDelete(model: KvdbEntryDeleteModel): Promise<types.core.OK>;
     kvdbListKeys(model: KvdbListKeysModel): Promise<KvdbListKeysResult>;

--- a/src/api/main/kvdb/KvdbApiValidator.ts
+++ b/src/api/main/kvdb/KvdbApiValidator.ts
@@ -89,6 +89,11 @@ export class KvdbApiValidator extends BaseValidator {
             kvdbEntryKey: this.tv.kvdbEntryKey,
         }));
         
+        this.registerMethod("kvdbEntryFind", this.builder.createObject({
+            kvdbId: this.tv.kvdbId,
+            kvdbEntryKey: this.tv.kvdbEntryKey,
+        }));
+        
         this.registerMethod("kvdbListKeys",  this.builder.addFields(this.tv.listModel, {
             kvdbId: this.tv.kvdbId,
             sortBy: this.builder.optional(this.builder.createEnum(["createDate", "entryKey", "lastModificationDate"])),

--- a/src/service/cloud/KvdbService.ts
+++ b/src/service/cloud/KvdbService.ts
@@ -289,6 +289,24 @@ export class KvdbService extends BaseContainerService {
         return {kvdb, item};
     }
     
+    async findKvdbEntry(executor: Executor, kvdbId: types.kvdb.KvdbId, entryKey: types.kvdb.KvdbEntryKey) {
+        const item = await this.repositoryFactory.createKvdbEntryRepository().get(kvdbId, entryKey);
+        if (!item) {
+            return null;
+        }
+        const kvdb = await this.repositoryFactory.createKvdbRepository().get(item.kvdbId);
+        if (!kvdb) {
+            throw new DbInconsistencyError(`kvdb=${item.kvdbId} does not exist, from item=${entryKey}`);
+        }
+        await this.cloudAccessValidator.checkIfCanExecuteInContext(executor, kvdb.contextId, (user, context) => {
+            if (!this.policy.canReadItem(user, context, kvdb, item)) {
+                throw new AppException("ACCESS_DENIED");
+            }
+            this.cloudAclChecker.verifyAccess(user.acl, "kvdb/kvdbEntryGet", ["kvdbId=" + kvdb.id, "entryKey=" + entryKey]);
+        });
+        return {kvdb, item};
+    }
+    
     async deleteItem(executor: Executor, kvdbId: types.kvdb.KvdbId, entryKey: types.kvdb.KvdbEntryKey) {
         const item = await this.repositoryFactory.createKvdbEntryRepository().get(kvdbId, entryKey);
         if (!item) {


### PR DESCRIPTION
## Summary

- Adds `kvdb.kvdbEntryFind` — a non-throwing alternative to `kvdb.kvdbEntryGet`
- Returns `{ kvdbEntry: null }` when the entry does not exist, instead of raising an error
- Reuses the existing `KvdbEntryGetModel` as input (same `kvdbId` + `kvdbEntryKey` fields)

## Motivation

`kvdbEntryGet` throws on a missing key, which forces callers to use try/catch just to probe for a key's existence. `kvdbEntryFind` makes the "entry may not exist" case a first-class result, enabling cleaner lock-before-write patterns without treating absence as a fault.
