### PR TITLE
feat: add random write API for store files (storeFileRw*)

### DIFF
--- a/src/api/AppException.ts
+++ b/src/api/AppException.ts
@@ -103,6 +103,7 @@ export const API_ERROR_CODES = {
     "KVDB_ENTRY_DOES_NOT_EXIST"              : {code: 0x613D, message: "Kvdb item does not exist"},
     "FIRST_API_KEY_ALREADY_EXISTS"          : {code: 0x613E, message: "First api key was already created"},
     "INITIALIZATION_TOKEN_MISSMATCH"        : {code: 0x613F, message: "Initialization token is invalid or not set"},
+    "STORE_FILE_RW_VERSION_MISMATCH"        : {code: 0x6140, message: "Store file random write version mismatch"},
     "FAILED_TO_SEND_MEDIA_EVENT"            : {code: 0x6200, message: "Failed to send Janus Event - no session found"},
     "NOT_SUBSCRIBED_FOR_STREAMS"            : {code: 0x6201, message: "Failed to leave streams - no session found"},
     "NOT_CONNECTED_TO_THE_ROOM"             : {code: 0x6202, message: "Failed to subscribe to stream/strams - not connected to the room"},

--- a/src/api/TypesValidator.ts
+++ b/src/api/TypesValidator.ts
@@ -64,6 +64,7 @@ export class TypesValidator {
     storeData: Validator;
     storeFileId: Validator;
     storeFileMeta: Validator;
+    storeFileOperations: Validator;
     listModel: ObjectValidator;
     inboxId: Validator;
     inboxData: Validator;
@@ -236,6 +237,20 @@ export class TypesValidator {
         this.storeData = this.unknown4Kb;
         this.storeFileId = id;
         this.storeFileMeta = this.unknown4Kb;
+        this.storeFileOperations = this.builder.createCustom((value, _validator, checker) => {
+            const storeFileOperation = this.builder.createObject({
+                type: this.builder.createEnum(["file", "checksum"]),
+                pos: this.builder.min(this.builder.int, -1),
+                data: this.byteBuffer,
+                truncate: this.builder.bool,
+            });
+            const maxSize = 5242880;
+            checker.validateValue(value, this.builder.createList(storeFileOperation));
+            const totalDataSize = (value as {data: Buffer}[]).reduce((sum, op) => sum + op.data.length, 0);
+            if (totalDataSize > maxSize) {
+                throw new Error(`Total operations data size ${totalDataSize} exceeds limit of ${maxSize} bytes`);
+            }
+        });
         this.queryValue = this.builder.createOneOf([this.builder.int, this.builder.string, this.builder.bool, this.builder.nullValue]);
         this.queryProperty = this.builder.createOneOf([this.queryValue, this.builder.createObject({
             $gt: this.builder.optional(this.builder.int),

--- a/src/api/main/store/StoreApi.ts
+++ b/src/api/main/store/StoreApi.ts
@@ -98,6 +98,18 @@ export class StoreApi extends BaseApi implements storeApi.IStoreApi {
     }
     
     @ApiMethod({})
+    async storeFileRwPull(model: storeApi.StoreFileRwPullModel): Promise<storeApi.StoreFileRwPullResult> {
+        const cloudUser = this.sessionService.validateContextSessionAndGetCloudUser();
+        const {randomWriteMeta, checksums, file, store} = await this.storeService.pullStoreFileRandomWriteMeta(cloudUser, model.fileId, model.rwVersion, model.version);
+        return {
+            meta: randomWriteMeta,
+            checksums,
+            store: store ? this.storeConverter.convertStore(cloudUser.getUser(store.contextId), store) : null,
+            file: file && store ? this.storeConverter.convertFile(store, file) : null,
+        };
+    }
+    
+    @ApiMethod({})
     async storeFileGetMany(model: storeApi.StoreFileGetManyModel): Promise<storeApi.StoreFileGetManyResult> {
         const cloudUser = this.sessionService.validateContextSessionAndGetCloudUser();
         const {store, files} = await this.storeService.getStoreFileMany(cloudUser, model.storeId, model.fileIds, model.failOnError);
@@ -138,9 +150,17 @@ export class StoreApi extends BaseApi implements storeApi.IStoreApi {
     }
     
     @ApiMethod({})
+    async storeFileRwCreate(model: storeApi.StoreFileRwCreateModel): Promise<storeApi.StoreFileCreateResult> {
+        const cloudUser = this.sessionService.validateContextSessionAndGetCloudUser();
+        const {store, file} = await this.storeService.createStoreFileRandomWrite(cloudUser, model);
+        this.requestLogger.setContextId(store.contextId);
+        return {fileId: file.id};
+    }
+    
+    @ApiMethod({})
     async storeFileRead(model: storeApi.StoreFileReadModel): Promise<storeApi.StoreFileReadResult> {
         const cloudUser = this.sessionService.validateContextSessionAndGetCloudUser();
-        const {store, data} = await this.storeService.readStoreFile(cloudUser, model.fileId, model.thumb, model.version, model.range);
+        const {store, data} = await this.storeService.readStoreFile(cloudUser, model.fileId, model.thumb, model.version, model.rwVersion, model.range);
         this.requestLogger.setContextId(store.contextId);
         return {data: data};
     }
@@ -151,6 +171,14 @@ export class StoreApi extends BaseApi implements storeApi.IStoreApi {
         const {store} = "requestId" in model ?
             await this.storeService.writeStoreFile(cloudUser, model) :
             await this.storeService.randomWrite(cloudUser, model);
+        this.requestLogger.setContextId(store.contextId);
+        return "OK";
+    }
+    
+    @ApiMethod({})
+    async storeFileRwWrite(model: storeApi.StoreFileRwWriteModel): Promise<types.core.OK> {
+        const cloudUser = this.sessionService.validateContextSessionAndGetCloudUser();
+        const {store} = await this.storeService.randomWriteWithMeta(cloudUser, model);
         this.requestLogger.setContextId(store.contextId);
         return "OK";
     }

--- a/src/api/main/store/StoreApiClient.ts
+++ b/src/api/main/store/StoreApiClient.ts
@@ -43,6 +43,10 @@ export class StoreApiClient extends BaseApiClient implements storeApi.IStoreApi 
         return this.request("store.storeFileGet", model);
     }
     
+    storeFileRwPull(model: storeApi.StoreFileRwPullModel): Promise<storeApi.StoreFileRwPullResult> {
+        return this.request("store.storeFileRwPull", model);
+    }
+    
     storeFileGetMany(model: storeApi.StoreFileGetManyModel): Promise<storeApi.StoreFileGetManyResult> {
         return this.request("store.storeFileGetMany", model);
     }
@@ -59,12 +63,20 @@ export class StoreApiClient extends BaseApiClient implements storeApi.IStoreApi 
         return this.request("store.storeFileCreate", model);
     }
     
+    storeFileRwCreate(model: storeApi.StoreFileRwCreateModel): Promise<storeApi.StoreFileCreateResult> {
+        return this.request("store.storeFileRwCreate", model);
+    }
+    
     storeFileRead(model: storeApi.StoreFileReadModel): Promise<storeApi.StoreFileReadResult> {
         return this.request("store.storeFileRead", model);
     }
     
     storeFileWrite(model: storeApi.StoreFileWriteModel): Promise<types.core.OK> {
         return this.request("store.storeFileWrite", model);
+    }
+    
+    storeFileRwWrite(model: storeApi.StoreFileRwWriteModel): Promise<types.core.OK> {
+        return this.request("store.storeFileRwWrite", model);
     }
     
     storeFileUpdate(model: storeApi.StoreFileUpdateModel): Promise<types.core.OK> {

--- a/src/api/main/store/StoreApiTypes.ts
+++ b/src/api/main/store/StoreApiTypes.ts
@@ -189,6 +189,19 @@ export interface StoreFileGetResult {
     file: StoreFile;
 }
 
+export interface StoreFileRwPullModel {
+    fileId: types.store.StoreFileId;
+    rwVersion: types.store.StoreFileRwVersion;
+    version?: types.store.StoreFileVersion;
+}
+
+export interface StoreFileRwPullResult {
+    meta: types.store.StoreFileRandomWriteMeta;
+    checksums: Buffer | null;
+    store: Store | null;
+    file: StoreFile | null;
+}
+
 export interface StoreFileGetManyModel {
     storeId: types.store.StoreId;
     fileIds: types.store.StoreFileId[];
@@ -226,6 +239,14 @@ export interface StoreFileCreateModel {
     thumbIndex?: number;
 }
 
+export interface StoreFileRwCreateModel {
+    storeId: types.store.StoreId;
+    resourceId?: types.core.ClientResourceId;
+    meta: types.store.StoreFileMeta;
+    keyId: types.core.KeyId;
+    rwMeta: types.store.StoreFileRwMeta;
+}
+
 export interface StoreFileCreateResult {
     fileId: types.store.StoreFileId;
 }
@@ -234,6 +255,7 @@ export interface StoreFileReadModel {
     fileId: types.store.StoreFileId;
     thumb: boolean;
     version?: types.store.StoreFileVersion;
+    rwVersion?: types.store.StoreFileRwVersion;
     range: types.store.BufferReadRange;
 }
 
@@ -261,6 +283,13 @@ export interface StoreFileWriteModelByOperations {
     keyId: types.core.KeyId;
     version: types.store.StoreFileVersion;
     force: boolean;
+}
+
+export interface StoreFileRwWriteModel {
+    fileId: types.store.StoreFileId;
+    operations: types.store.StoreFileRandomWriteOperation[];
+    rwVersion: types.store.StoreFileRwVersion;
+    rwMeta: types.store.StoreFileRwMeta;
 }
 
 export interface StoreFileUpdateModel {
@@ -327,12 +356,15 @@ export interface IStoreApi {
     storeList(model: StoreListModel): Promise<StoreListResult>;
     storeListAll(model: StoreListAllModel): Promise<StoreListAllResult>
     storeFileGet(model: StoreFileGetModel): Promise<StoreFileGetResult>;
+    storeFileRwPull(model: StoreFileRwPullModel): Promise<StoreFileRwPullResult>;
     storeFileGetMany(model: StoreFileGetManyModel): Promise<StoreFileGetManyResult>;
     storeFileList(model: StoreFileListModel): Promise<StoreFileListResult>;
     storeFileListMy(model: StoreFileListMyModel): Promise<StoreFileListMyResult>;
     storeFileCreate(model: StoreFileCreateModel): Promise<StoreFileCreateResult>;
+    storeFileRwCreate(model: StoreFileRwCreateModel): Promise<StoreFileCreateResult>;
     storeFileRead(model: StoreFileReadModel): Promise<StoreFileReadResult>;
     storeFileWrite(model: StoreFileWriteModel): Promise<types.core.OK>;
+    storeFileRwWrite(model: StoreFileRwWriteModel): Promise<types.core.OK>;
     storeFileUpdate(model: StoreFileUpdateModel): Promise<types.core.OK>;
     storeFileDelete(model: StoreFileDeleteModel): Promise<types.core.OK>;
     storeFileDeleteMany(model: StoreFileDeleteManyModel): Promise<StoreFileDeleteManyResult>;

--- a/src/api/main/store/StoreApiValidator.ts
+++ b/src/api/main/store/StoreApiValidator.ts
@@ -66,6 +66,11 @@ export class StoreApiValidator extends BaseValidator {
         this.registerMethod("storeFileGet", this.builder.createObject({
             fileId: this.tv.storeFileId,
         }));
+        this.registerMethod("storeFileRwPull", this.builder.createObject({
+            fileId: this.tv.storeFileId,
+            rwVersion: this.tv.intNonNegative,
+            version: this.builder.optional(this.tv.intNonNegative),
+        }));
         this.registerMethod("storeFileGetMany", this.builder.createObject({
             storeId: this.tv.storeId,
             fileIds: this.builder.createListWithMaxLength(this.tv.storeFileId, 100),
@@ -88,10 +93,18 @@ export class StoreApiValidator extends BaseValidator {
             keyId: this.tv.keyId,
             thumbIndex: this.builder.optional(this.builder.int),
         }));
+        this.registerMethod("storeFileRwCreate", this.builder.createObject({
+            storeId: this.tv.storeId,
+            resourceId: this.builder.optional(this.tv.uuidv4),
+            meta: this.tv.storeFileMeta,
+            keyId: this.tv.keyId,
+            rwMeta: this.tv.unknown4Kb,
+        }));
         this.registerMethod("storeFileRead", this.builder.createObject({
             fileId: this.tv.storeFileId,
             thumb: this.builder.bool,
             version: this.builder.optional(this.tv.intNonNegative),
+            rwVersion: this.builder.optional(this.tv.intNonNegative),
             range: this.tv.bufferReadRange,
         }));
         this.registerMethod("storeFileWrite", this.builder.createOneOf([
@@ -114,6 +127,12 @@ export class StoreApiValidator extends BaseValidator {
                 force: this.builder.bool,
             }),
         ]));
+        this.registerMethod("storeFileRwWrite", this.builder.createObject({
+            fileId: this.tv.storeFileId,
+            operations: this.tv.storeFileOperations,
+            rwVersion: this.tv.intNonNegative,
+            rwMeta: this.tv.unknown4Kb,
+        }));
         this.registerMethod("storeFileUpdate", this.builder.createObject({
             fileId: this.tv.storeFileId,
             resourceId: this.builder.optional(this.tv.uuidv4),

--- a/src/api/main/store/StoreApiValidator.ts
+++ b/src/api/main/store/StoreApiValidator.ts
@@ -108,12 +108,7 @@ export class StoreApiValidator extends BaseValidator {
             this.builder.createObject({
                 fileId: this.tv.storeFileId,
                 meta: this.tv.storeFileMeta,
-                operations: this.builder.createListWithRangeLength(this.builder.createObject({
-                    type: this.builder.createEnum(["file", "checksum"]),
-                    pos: this.builder.min(this.builder.int, -1),
-                    data: this.builder.maxLength(this.tv.byteBuffer, 524288),
-                    truncate: this.builder.bool,
-                }), 1, 4),
+                operations: this.tv.storeFileOperations,
                 keyId: this.tv.keyId,
                 version: this.tv.intNonNegative,
                 force: this.builder.bool,

--- a/src/db/Model.ts
+++ b/src/db/Model.ts
@@ -247,6 +247,7 @@ export namespace store {
         };
         updates?: types.store.StoreFileUpdate[];
         supportsRandomWrite?: boolean;
+        randomWriteMeta?: types.store.StoreFileRandomWriteMeta;
     }
 }
 

--- a/src/service/cloud/StoreFileRepository.ts
+++ b/src/service/cloud/StoreFileRepository.ts
@@ -95,6 +95,27 @@ export class StoreFileRepository {
         return nFile;
     }
     
+    async createRandomWrite(storeId: types.store.StoreId, resourceId: types.core.ClientResourceId|null, author: types.cloud.UserId, meta: types.store.StoreFileMeta, keyId: types.core.KeyId, fileId: types.request.FileId, randomWriteMeta: types.store.StoreFileRandomWriteMeta) {
+        const nFile: db.store.StoreFile = {
+            id: this.repository.generateId(),
+            storeId: storeId,
+            author: author,
+            createDate: DateUtils.now(),
+            meta: meta,
+            keyId: keyId,
+            fileId: fileId,
+            size: 0 as types.core.SizeInBytes,
+            checksumSize: 0 as types.core.SizeInBytes,
+            supportsRandomWrite: true,
+            randomWriteMeta: randomWriteMeta,
+        };
+        if (resourceId) {
+            nFile.clientResourceId = resourceId;
+        }
+        await this.repository.insert(nFile);
+        return nFile;
+    }
+    
     async update(oldFile: db.store.StoreFile, modifier: types.cloud.UserId, meta: types.store.StoreFileMeta, keyId: types.core.KeyId, file: db.request.FileDefinition, thumb: db.request.FileDefinition|undefined) {
         const updates = oldFile.updates || [];
         updates.push({
@@ -146,7 +167,7 @@ export class StoreFileRepository {
     async updateMetaWithSize(oldFile: db.store.StoreFile, modifier: types.cloud.UserId, meta: types.store.StoreFileMeta, keyId: types.core.KeyId, size: {
         newFileSize?: number,
         newChecksumSize?: number;
-    }) {
+    }, randomWriteMeta?: types.store.StoreFileRandomWriteMeta) {
         const updates = oldFile.updates || [];
         updates.push({
             createDate: DateUtils.now(),
@@ -159,6 +180,24 @@ export class StoreFileRepository {
             size: size.newFileSize as types.core.SizeInBytes,
             checksumSize: size.newChecksumSize as types.core.SizeInBytes,
             updates: updates,
+            ...(randomWriteMeta !== undefined ? {randomWriteMeta} : {}),
+        };
+        await this.repository.update(nFile);
+        return nFile;
+    }
+    
+    async updateRandomWriteMeta(oldFile: db.store.StoreFile, size: {
+        newFileSize?: number,
+        newChecksumSize?: number;
+    }, rwMeta: types.store.StoreFileRwMeta) {
+        const nFile: db.store.StoreFile = {
+            ...oldFile,
+            size: size.newFileSize as types.core.SizeInBytes,
+            checksumSize: size.newChecksumSize as types.core.SizeInBytes,
+            randomWriteMeta: {
+                rwMeta: rwMeta,
+                rwVersion: oldFile.randomWriteMeta!.rwVersion + 1 as types.store.StoreFileRwVersion,
+            },
         };
         await this.repository.update(nFile);
         return nFile;

--- a/src/service/cloud/StoreService.ts
+++ b/src/service/cloud/StoreService.ts
@@ -279,6 +279,32 @@ export class StoreService extends BaseContainerService {
         return {file, store};
     }
     
+    async pullStoreFileRandomWriteMeta(executor: Executor, fileId: types.store.StoreFileId, rwVersion: types.store.StoreFileRwVersion, version: types.store.StoreFileVersion|undefined) {
+        const file = await this.repositoryFactory.createStoreFileRepository().get(fileId);
+        if (!file) {
+            throw new AppException("STORE_FILE_DOES_NOT_EXIST");
+        }
+        const store = await this.repositoryFactory.createStoreRepository().get(file.storeId);
+        if (!store) {
+            throw new DbInconsistencyError(`store=${file.storeId} does not exist, from file=${fileId}`);
+        }
+        await this.cloudAccessValidator.checkIfCanExecuteInContext(executor, store.contextId, (user, context) => {
+            this.cloudAclChecker.verifyAccess(user.acl, "store/storeFileGet", ["storeId=" + store.id, "fileId=" + fileId]);
+            if (!this.policy.canReadItem(user, context, store, file)) {
+                throw new AppException("ACCESS_DENIED");
+            }
+        });
+        if (!file.randomWriteMeta) {
+            throw new AppException("UNSUPPORTED_OPERATION", "File does not have randomWriteMeta");
+        }
+        const randomWriteMeta = file.randomWriteMeta;
+        const checksums = randomWriteMeta.rwVersion > rwVersion
+            ? await this.storageService.getStorageService("randomWrite").read(file.fileId, {type: "checksum"})
+            : null;
+        const versionChanged = typeof version === "number" && this.getFileVersion(file) !== version;
+        return {randomWriteMeta, checksums, file: versionChanged ? file : null, store: versionChanged ? store : null};
+    }
+    
     async getStoreFileMany(executor: Executor, storeId: types.store.StoreId, fileIds: types.store.StoreFileId[], failOnError: boolean) {
         const store = await this.repositoryFactory.createStoreRepository().get(storeId);
         if (!store) {
@@ -416,6 +442,35 @@ export class StoreService extends BaseContainerService {
         }
     }
     
+    async createStoreFileRandomWrite(cloudUser: CloudUser, model: storeApi.StoreFileRwCreateModel) {
+        const {user, context, store} = await this.getStoreAndUser(cloudUser, model.storeId);
+        if (!this.policy.canCreateItem(user, context, store)) {
+            throw new AppException("ACCESS_DENIED");
+        }
+        this.cloudAclChecker.verifyAccess(user.acl, "store/storeFileCreate", ["storeId=" + model.storeId]);
+        if (model.keyId !== store.keyId) {
+            throw new AppException("INVALID_KEY");
+        }
+        const fileId = this.repositoryFactory.generateId() as types.request.FileId;
+        const storageService = this.storageService.getStorageService("randomWrite");
+        await storageService.create(fileId);
+        await storageService.setChecksumAndClose(fileId, Buffer.alloc(0), 1);
+        await storageService.commit(fileId);
+        try {
+            const file = await this.repositoryFactory.createStoreFileRepository().createRandomWrite(model.storeId, model.resourceId || null, user.userId, model.meta, model.keyId, fileId, {rwVersion: 1 as types.store.StoreFileRwVersion, rwMeta: model.rwMeta});
+            await this.repositoryFactory.createStoreRepository().increaseFilesCounter(store.id, file.createDate);
+            this.storeNotificationService.sendStoreFileCreated(store, file, context.solution);
+            this.storeNotificationService.sendStoreStatsChanged({...store, files: store.files + 1, lastFileDate: file.createDate}, context.solution);
+            return {file, store, user};
+        }
+        catch (err) {
+            if (err instanceof DbDuplicateError) {
+                throw new AppException("DUPLICATE_RESOURCE_ID");
+            }
+            throw err;
+        }
+    }
+    
     async writeStoreFile(cloudUser: CloudUser, model: storeApi.StoreFileWriteModelByRequest) {
         const oldFile = await this.repositoryFactory.createStoreFileRepository().get(model.fileId);
         if (!oldFile) {
@@ -487,6 +542,34 @@ export class StoreService extends BaseContainerService {
             return await this.repositoryFactory.withTransaction(async (session) => {
                 const {newFileSize, newChecksumSize} = await this.storageService.getStorageService(oldFile.supportsRandomWrite ? "randomWrite" : "regular").randomWriteCommit(randomWriteContext, session);
                 const file = await this.repositoryFactory.createStoreFileRepository(session).updateMetaWithSize(oldFile, user.userId, model.meta, model.keyId, {newFileSize, newChecksumSize});
+                return {file, store, user, context};
+            });
+        });
+        this.storeNotificationService.sendStoreFileUpdated(rStore, rFile, rContext.solution, model.operations);
+        return {file: rFile, store: rStore, user: rUser};
+    }
+    
+    async randomWriteWithMeta(cloudUser: CloudUser, model: storeApi.StoreFileRwWriteModel) {
+        const {file: rFile, store: rStore, user: rUser, context: rContext} = await this.lockHelper.withLock(`random-write-${model.fileId}`, async () => {
+            const oldFile = await this.repositoryFactory.createStoreFileRepository().get(model.fileId);
+            if (!oldFile) {
+                throw new AppException("STORE_FILE_DOES_NOT_EXIST");
+            }
+            const {user, context, store} = await this.getStoreAndUser(cloudUser, oldFile.storeId);
+            this.cloudAclChecker.verifyAccess(user.acl, "store/storeFileWrite", ["storeId=" + store.id, "fileId=" + model.fileId]);
+            if (!this.policy.canUpdateItem(user, context, store, oldFile)) {
+                throw new AppException("ACCESS_DENIED");
+            }
+            if (!oldFile.supportsRandomWrite) {
+                throw new AppException("UNSUPPORTED_OPERATION", "Random write can be only executed on files supporting this operation");
+            }
+            if (oldFile.randomWriteMeta !== undefined && oldFile.randomWriteMeta.rwVersion !== model.rwVersion) {
+                throw new AppException("INVALID_VERSION", `randomWriteMeta version does not match, got: ${model.rwVersion}, expected: ${oldFile.randomWriteMeta.rwVersion}`);
+            }
+            const randomWriteContext = await this.storageService.getStorageService("randomWrite").randomWritePrepare(oldFile.fileId, model.operations);
+            return await this.repositoryFactory.withTransaction(async (session) => {
+                const {newFileSize, newChecksumSize} = await this.storageService.getStorageService("randomWrite").randomWriteCommit(randomWriteContext, session);
+                const file = await this.repositoryFactory.createStoreFileRepository(session).updateRandomWriteMeta(oldFile, {newFileSize, newChecksumSize}, model.rwMeta);
                 return {file, store, user, context};
             });
         });
@@ -627,7 +710,7 @@ export class StoreService extends BaseContainerService {
         return this.deleteManyStoreFiles(executor, storeFiles.map(file => file.id), false);
     }
     
-    async readStoreFile(cloudUser: CloudUser, fileId: types.store.StoreFileId, thumb: boolean, version: types.store.StoreFileVersion|undefined, range: types.store.BufferReadRange) {
+    async readStoreFile(cloudUser: CloudUser, fileId: types.store.StoreFileId, thumb: boolean, version: types.store.StoreFileVersion|undefined, rwVersion: types.store.StoreFileRwVersion|undefined, range: types.store.BufferReadRange) {
         const file = await this.repositoryFactory.createStoreFileRepository().get(fileId);
         if (!file) {
             throw new AppException("STORE_FILE_DOES_NOT_EXIST");
@@ -639,6 +722,9 @@ export class StoreService extends BaseContainerService {
         this.cloudAclChecker.verifyAccess(user.acl, "store/storeFileRead", ["storeId=" + store.id, "fileId=" + fileId]);
         if (typeof(version) === "number" && this.getFileVersion(file) !== version) {
             throw new AppException("STORE_FILE_VERSION_MISMATCH");
+        }
+        if (typeof(rwVersion) === "number" && file.randomWriteMeta?.rwVersion !== rwVersion) {
+            throw new AppException("STORE_FILE_RW_VERSION_MISMATCH");
         }
         const fileIdToRead = (() => {
             if (thumb) {

--- a/src/test/service/cloud/StoreService.test.ts
+++ b/src/test/service/cloud/StoreService.test.ts
@@ -611,7 +611,7 @@ it("Should read store file data", async () => {
     const {storeService, storageService} = createStoreService();
     
     // Act
-    const res = await storeService.readStoreFile(janekUserPubKey, storeFileId, false, undefined, {type: "all"});
+    const res = await storeService.readStoreFile(janekUserPubKey, storeFileId, false, undefined, undefined, {type: "all"});
     
     // Asserts
     expect(res).not.toBeNull();
@@ -624,7 +624,7 @@ it("Should read store file thumb data", async () => {
     const {storeService, storageService} = createStoreService();
     
     // Act
-    const res = await storeService.readStoreFile(janekUserPubKey, storeFileId, true, undefined, {type: "all"});
+    const res = await storeService.readStoreFile(janekUserPubKey, storeFileId, true, undefined, undefined, {type: "all"});
     
     // Asserts
     expect(res).not.toBeNull();
@@ -633,19 +633,19 @@ it("Should read store file thumb data", async () => {
 });
 
 testFail("Should fails on reading with invalid user", "ACCESS_DENIED", storeService =>
-    storeService.readStoreFile(bobUserPubKey, storeFileId, false, undefined, {type: "all"}),
+    storeService.readStoreFile(bobUserPubKey, storeFileId, false, undefined, undefined, {type: "all"}),
 );
 
 testFail("Should fails on reading with user without access", "ACCESS_DENIED", storeService =>
-    storeService.readStoreFile(aliceUserPubKey, storeFileId, false, undefined, {type: "all"}),
+    storeService.readStoreFile(aliceUserPubKey, storeFileId, false, undefined, undefined, {type: "all"}),
 );
 
 testFail("Should fails on reading not exisitng file", "STORE_FILE_DOES_NOT_EXIST", storeService =>
-    storeService.readStoreFile(janekUserPubKey, notExistingStoreFileId, false, undefined, {type: "all"}),
+    storeService.readStoreFile(janekUserPubKey, notExistingStoreFileId, false, undefined, undefined, {type: "all"}),
 );
 
 testFail("Should fails on reading not exisitng thumb", "FILES_CONTAINER_FILE_HAS_NOT_THUMB", storeService =>
-    storeService.readStoreFile(janekUserPubKey, storeFileIdWithoutThumb, true, undefined, {type: "all"}),
+    storeService.readStoreFile(janekUserPubKey, storeFileIdWithoutThumb, true, undefined, undefined, {type: "all"}),
 );
 
 function createStoreService() {

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -18,6 +18,8 @@ export type StoreVersion = number&{__storeVersion: never};
 export type StoreType = string&{__storeType: never};
 export type StoreFileMeta = unknown;
 export type StoreFileVersion = number&{__storeFileVersion: never};
+export type StoreFileRwMeta = unknown;
+export type StoreFileRwVersion = number&{__storeFileRwVersion: never};
 
 export interface StoreFileUpdate {
     createDate: types.core.Timestamp;
@@ -56,3 +58,7 @@ export interface StoreFileFetchError {
     error: {code: number; message: string;};
 }
 
+export interface StoreFileRandomWriteMeta {
+    rwVersion: StoreFileRwVersion;
+    rwMeta: StoreFileRwMeta;
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on**: 
>   - #16
> Do not merge before.

## Summary

- Introduces three new endpoints for random-write store files: `storeFileRwCreate`, `storeFileRwWrite`, `storeFileRwPull`
- Adds `StoreFileRwVersion` and `StoreFileRwMeta` branded types, renames `randomWriteMeta` fields to `rwVersion`/`rwMeta` for consistency across the API
- Extends `storeFileRead` with an optional `rwVersion` parameter and adds a dedicated `STORE_FILE_RW_VERSION_MISMATCH` error (code `0x6140`)

## New endpoints

**`storeFileRwCreate`** — creates a new random-write file. Client provides `rwMeta`; server initializes `rwVersion` to `1`.

**`storeFileRwWrite`** — applies random-write operations with optimistic locking. Client passes current `rwVersion` (fetched via `storeFileRwPull`); server rejects with `INVALID_VERSION` if it doesn't match.

**`storeFileRwPull`** — fetches current `randomWriteMeta` and checksums. Accepts optional `version` (file update version); if the file has changed since the client's known version, the response also includes updated `store` and `file` objects.

